### PR TITLE
Ensure opts.config exists before checking it

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var transformTools = require('browserify-transform-tools');
 
 module.exports = transformTools.makeRequireTransform('literalify', {}, function(args, opts, cb) {
-  if (args[0] in opts.config) {
+  if (opts.config && args[0] in opts.config) {
     return cb(null, opts.config[args[0]]);
   } else {
     return cb();


### PR DESCRIPTION
Without this I get the following:

```
TypeError: Cannot use 'in' operator to search for '../../../../common/assets/js/flashMessage' in undefined (while literalify was processing /.../assets/js-browserify/app/flashMessageTemplate.coffee)
    at /.../common/node_modules/literalify/index.js:5:22
    at /.../common/node_modules/literalify/node_modules/browserify-transform-tools/lib/transformTools.js:241:16
    ...
```

I'm also using coffeeify and browserify-middleware - and using package.json to specify literalify options.
