### PR TITLE
Don't npm publish unnecessary spec and example directories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+spec
+examples


### PR DESCRIPTION
Figure these directories aren't necessary to publish to npm - the less bytes the better! :smile_cat: 
